### PR TITLE
Build Out Endpoint For Admin To Disapprove Request

### DIFF
--- a/server/controllers/adminController.js
+++ b/server/controllers/adminController.js
@@ -66,6 +66,24 @@ class AdminController {
       return res.status(404).send('The specified request does not exist');
     });
   }
+
+  /**
+   * (Admin) Approve a request a user has made
+   * @param {string} token - Takes in a token string
+   * @param {number} id - Takes in a request id
+   * @return a response 200 if the process was successful
+   */
+  static disapproveRequest(req, res) {
+    pool.query(`UPDATE requests SET status_id = 3 WHERE id = ${req.params.id}`, (error, result) => {
+      if (error) {
+        return res.status(500).send('An error occured when disapproving the request');
+      }
+      if (result.rowCount > 0) {
+        return res.status(200).send('Request updated successfully');
+      }
+      return res.status(404).send('The specified request does not exist');
+    });
+  }
 }
 
 export default AdminController;

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -5,6 +5,7 @@ import AdminController from '../controllers/adminController';
 
 adminRoutes.get('/requests', VerifyToken, VerifyAdmin, AdminController.getAllRequests);
 adminRoutes.get('/requests/:id', VerifyToken, VerifyAdmin, AdminController.getSingleRequest);
-adminRoutes.put('/requests/:id', VerifyToken, VerifyAdmin, AdminController.approveRequest);
+adminRoutes.put('/requests/:id/approve', VerifyToken, VerifyAdmin, AdminController.approveRequest);
+adminRoutes.put('/requests/:id/disapprove', VerifyToken, VerifyAdmin, AdminController.disapproveRequest);
 
 export default adminRoutes;


### PR DESCRIPTION
#### What does this PR do?
Allow an admin to disapprove a request

#### Description of Task to be completed?
Created the endpoint
PUT /requests/{id}/disapprove

#### How should this be manually tested?
After cloning the repo and running `npm install`, run `npm test` to run the tests
On Postman, test the endpoint above with:
token: ADMIN_TOKEN
id: REQUEST_ID

#### What are the relevant pivotal tracker stories?
#157798085
