### PR TITLE
Build Out Feature For User To View Single Request On FrontEnd

### DIFF
--- a/frontend/assets/js/dashboard.js
+++ b/frontend/assets/js/dashboard.js
@@ -28,7 +28,7 @@ const dashboard = () => {
                             <h3 class="title"><strong>Title: </strong>${request.title}</h3>
                             <p><strong>Description: </strong>${request.title.substring(0, 150)}</p>
                           </div>
-                          <a href="view-request.html" class="btn btn-green fit-content">View Request</a>
+                          <a href="/${request.id}" class="btn btn-green fit-content">View Request</a>
                         </div>
                         <hr>`;
           });

--- a/frontend/assets/js/single.js
+++ b/frontend/assets/js/single.js
@@ -1,0 +1,73 @@
+const url = '/api/v1/users/requests';
+const requestDiv = document.querySelector('.request-single');
+const messageBox = document.querySelector('.message');
+const token = localStorage['ascii-mt-token'];
+
+const single = () => {
+  const pageUrlArray = document.URL.split('/');
+  const pageUrl = pageUrlArray[pageUrlArray.length - 1];
+  fetch(`${url}/${pageUrl}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    credentials: 'same-origin',
+  }).then((response) => {
+    response.json().then((message) => {
+      if (response.status !== 200) {
+        messageBox.classList.add('message-failure');
+        messageBox.innerHTML = message.message;
+        messageBox.classList.remove('hide');
+      } else {
+        let status;
+        switch (message.status) {
+          case 1:
+            status = '<span class="btn btn-sm btn-orange mb-10 in-review"> In review</span>';
+            break;
+          case 2:
+            status = '<span class="btn btn-sm btn-green mb-10 approved"> Approved</span>';
+            break;
+          case 3:
+            status = '<span class="btn btn-sm btn-red mb-10 disapproved"> Disapproved</span>';
+            break;
+          default:
+            status = '<span class="btn btn-sm btn-green mb-10 resolved"> Resolved</span>';
+            break;
+        }
+        const request = `
+        <div class="small-container div-center">
+          <h1 class="lead text-center mb-10">${message.title}</h1>
+        </div>
+        <div class="small-container flex row div-center">
+          <div class="card text-center col fit-content">
+            <div>
+              <p class="mt-10"><strong>Status:</strong> ${status}</p>
+              <hr>
+              <p class="request-date mt-10"><strong>Created at:</strong> ${new Date(message.created_at).toDateString()}</p>
+              <hr>                  
+              ${(message.status === 1) ? '<a href="#" class="btn btn-green btn-full mt-10">Edit</a>' : ''}
+              <hr>
+              ${(message.status === 1) ? '<a href="#" class="btn btn-red btn-full mt-10">Delete</a>' : ''}
+            </div>
+          </div>
+          <div class="requests card flex-2">
+            <strong>Description:</strong>
+            <hr>
+            <p class="content mt-10">
+              ${message.description}
+            </p>
+          </div>
+        </div>
+        `;
+        requestDiv.innerHTML = request;
+      }
+    });
+  })
+    .catch((err) => {
+      console.log(err);
+    });
+  return null;
+};
+
+single();

--- a/frontend/views/modify.html
+++ b/frontend/views/modify.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Maintenance Tracker</title>
+    <link href="https://fonts.googleapis.com/css?family=Poppins" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Gloria+Hallelujah" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/style.css">
+    <link rel="stylesheet" href="assets/css/responsive.css">
+</head>
+<body>
+  <div class="vh85">
+    <header class="navigation orange-bg">
+      <div class="container div-center">
+        <div class="flex space-between">
+          <div class="logo">
+            <a href="/" class="logo-text white-text">MT</a>
+          </div>
+          <nav class="main-nav pt-10">
+            <ul class="flex">
+              <li>
+                <a href="/dashboard" class="white-text">Dashboard</a>
+              </li>
+              <li>
+                <a href="/create" class="white-text">Make Request</a>
+              </li>
+              <li>
+                <a href="#" class="white-text">Logout</a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </header>
+    <section class="main">
+      <div class="small-container div-center">
+        <h1 class="lead text-center mb-10">Create Request</h1>
+      </div>
+      <div class="small-container div-center">
+        <div class="requests card">
+          <form id="create-form" method="POST">
+            <div class="message hide"></div>
+            <div class="form-group">
+              <label for="request-title">Title</label>
+              <input type="text" name="title" id="request-title" class="form-control" placeholder="Enter a title for your request" required="required">
+            </div>
+            <div class="form-group">
+              <label for="request-type">Request Type</label>
+              <select class="form-control" name="type" id="request-type" required="required">
+                  <option>Select one</option>
+                  <option value="maintenance">Maintenance</option>
+                  <option value="repair">Repair</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <label for="request-description">Description</label>
+              <textarea type="text" name="description" id="request-description" class="form-control" placeholder="Describe your request in detail" required="required"></textarea>
+            </div>
+            <div class="form-group">
+              <button type="submit" class="btn btn-lg btn-green">Submit</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </section>
+  </div>
+  <footer class="footer orange-bg">
+    <div class="container div-center flex space-between pt-10">
+      <div>
+        <a href="/" class="white-text">&copy; 2018, Maintenance Tracker</a>
+      </div>
+    </div>
+  </footer>
+  <script src="assets/js/create.js"></script>
+</body>
+</html>

--- a/frontend/views/single.html
+++ b/frontend/views/single.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Maintenance Tracker</title>
+    <link href="https://fonts.googleapis.com/css?family=Poppins" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Gloria+Hallelujah" rel="stylesheet">
+    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/assets/css/responsive.css">
+</head>
+<body>
+  <div class="vh85">
+    <header class="navigation orange-bg">
+        <div class="container div-center">
+            <div class="flex space-between">
+                <div class="logo">
+                    <a href="/" class="logo-text white-text">MT</a>
+                </div>
+                <nav class="main-nav pt-10">
+                    <ul class="flex">
+                        <li>
+                            <a href="/dashboard" class="white-text">Dashboard</a>
+                        </li>
+                        <li>
+                            <a href="/create" class="white-text">Make Request</a>
+                        </li>
+                        <li>
+                            <a href="#" class="white-text">Logout</a>
+                        </li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    </header>
+    <section class="main request-single">
+      <!-- Single Request -->
+    </section>
+  </div>
+  <footer class="footer orange-bg">
+    <div class="container div-center flex space-between pt-10">
+        <div>
+            <a href="/" class="white-text">&copy; 2018, Maintenance Tracker</a>
+        </div>
+    </div>
+  </footer>
+  <script src="/assets/js/single.js"></script>
+</body>
+</html>

--- a/server/controllers/RequestController.js
+++ b/server/controllers/RequestController.js
@@ -31,10 +31,15 @@ class RequestController {
         return res.status(400).json({ message: 'The request ID must be a number' });
       }
       if (result.rowCount === 0) {
-        return res.status(404).json({ message: 'The user could not be found' });
+        return res.status(404).json({ message: 'The request could not be found' });
       }
       return res.status(200).json({
-        requests: result.rows,
+        id: result.rows[0].id,
+        title: result.rows[0].title,
+        type: result.rows[0].type,
+        description: result.rows[0].description,
+        created_at: result.rows[0].created_at,
+        status: result.rows[0].status_id,
         message: 'Single request',
       });
     });
@@ -100,6 +105,7 @@ class RequestController {
             return res.status(500).json({ message: 'An error occured while processing this request inner' });
           }
           return res.status(200).json({
+            id: result.rows[0].id,
             title: response.rows[0].title,
             type: response.rows[0].type,
             description: response.rows[0].description,

--- a/server/routes/frontend.js
+++ b/server/routes/frontend.js
@@ -8,5 +8,6 @@ frontendRoutes.get('/signup', (req, res) => { res.sendFile('signup.html', { root
 frontendRoutes.get('/login', (req, res) => { res.sendFile('login.html', { root }); });
 frontendRoutes.get('/dashboard', (req, res) => { res.sendFile('dashboard.html', { root }); });
 frontendRoutes.get('/create', (req, res) => { res.sendFile('create.html', { root }); });
+frontendRoutes.get('/requests/:id', (req, res) => { res.sendFile('single.html', { root }); });
 
 export default frontendRoutes;


### PR DESCRIPTION
#### What does this PR do?
For user to be able to view details about a single request

#### Description of Task to be completed?
Imported the single request page ui and created the route
/requests/<requestId>

#### How should this be manually tested?
After cloning the repo and running `npm install`
run `npm run dev` to start the server and 
point your browser to `http://localhost:8080/requests/<requestId>`
after login or signup

#### What are the relevant pivotal tracker stories?
#158144747