### PR TITLE
 feature admin view single request fe

### DIFF
--- a/frontend/assets/js/admin/dashboard.js
+++ b/frontend/assets/js/admin/dashboard.js
@@ -31,7 +31,7 @@ const dashboard = () => {
                             <!-- <p><strong>By: </strong> Samuel Afolaranmi</p> -->
                             <p><strong>Created at: </strong> ${new Date(request.created_at).toDateString()}</p>
                           </div>
-                          <a href="#" class="btn btn-green fit-content">View Request</a>
+                          <a href="/admin/requests/${request.id}" class="btn btn-green fit-content">View Request</a>
                         </div>
                         <hr>
                         `;

--- a/frontend/assets/js/admin/single.js
+++ b/frontend/assets/js/admin/single.js
@@ -1,0 +1,73 @@
+const url = '/api/v1/requests';
+const requestDiv = document.querySelector('.request-single');
+const messageBox = document.querySelector('.message');
+const token = localStorage['ascii-mt-token'];
+
+const single = () => {
+  const pageUrlArray = document.URL.split('/');
+  const pageUrl = pageUrlArray[pageUrlArray.length - 1];
+  fetch(`${url}/${pageUrl}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    credentials: 'same-origin',
+  }).then((response) => {
+    response.json().then((message) => {
+      if (response.status !== 200) {
+        messageBox.classList.add('message-failure');
+        messageBox.innerHTML = message.message;
+        messageBox.classList.remove('hide');
+      } else {
+        let status;
+        switch (message.status) {
+          case 1:
+            status = '<span class="btn btn-sm btn-orange mb-10 in-review"> In review</span>';
+            break;
+          case 2:
+            status = '<span class="btn btn-sm btn-green mb-10 approved"> Approved</span>';
+            break;
+          case 3:
+            status = '<span class="btn btn-sm btn-red mb-10 disapproved"> Disapproved</span>';
+            break;
+          default:
+            status = '<span class="btn btn-sm btn-green mb-10 resolved"> Resolved</span>';
+            break;
+        }
+        const request = `
+        <div class="small-container div-center">
+          <h1 class="lead text-center mb-10">${message.title}</h1>
+        </div>
+        <div class="small-container flex row div-center">
+          <div class="card text-center col fit-content">
+            <div>
+              <p class="mt-10"><strong>Status:</strong> <span class="in-review">${status}</span></p>
+              <hr>
+              <p class="request-date mt-10"><strong>Created at:</strong> ${new Date(message.created_at).toDateString()}</p>
+              <hr>                  
+              ${(message.status === 1 || message.status === 3) ? '<a href="#" class="btn btn-green btn-full mt-10">Accept</a>' : ''}
+              ${(message.status === 1) ? '<a href="#" class="btn btn-red btn-full mt-10">Reject</a>' : ''}
+              ${(message.status === 2) ? '<a href="#" class="btn btn-orange btn-full mt-10">Resolve</a>' : ''}
+            </div>
+          </div>
+          <div class="requests card flex-2">
+            <strong>Description:</strong>
+            <hr>
+            <p class="content mt-10">
+              ${message.description}
+            </p>
+          </div>
+        </div>
+        `;
+        requestDiv.innerHTML = request;
+      }
+    });
+  })
+    .catch((err) => {
+      console.log(err);
+    });
+  return null;
+};
+
+single();

--- a/frontend/views/admin/single.html
+++ b/frontend/views/admin/single.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Maintenance Tracker</title>
+    <link href="https://fonts.googleapis.com/css?family=Poppins" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Gloria+Hallelujah" rel="stylesheet">
+    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="/assets/css/responsive.css">
+</head>
+<body>
+  <div class="vh85">
+    <header class="navigation orange-bg">
+        <div class="container div-center">
+            <div class="flex space-between">
+                <div class="logo">
+                    <a href="/admin" class="logo-text white-text">MT</a>
+                </div>
+                <nav class="main-nav pt-10">
+                    <ul class="flex">
+                        <li>
+                            <a href="/admin" class="white-text">Dashboard</a>
+                        </li>
+                        <li>
+                            <a href="#" class="white-text">Logout</a>
+                        </li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
+    </header>
+    <section class="main request-single">
+      <!-- single request details -->
+    </section>
+  </div>
+  <footer class="footer orange-bg">
+    <div class="container div-center flex space-between pt-10">
+        <div>
+            <a href="/admin" class="white-text">&copy; 2018, Maintenance Tracker</a>
+        </div>
+    </div>
+  </footer>
+  <script src="/assets/js/admin/single.js"></script>
+</body>
+</html>

--- a/server/routes/frontend.js
+++ b/server/routes/frontend.js
@@ -11,5 +11,6 @@ frontendRoutes.get('/create', (req, res) => { res.sendFile('create.html', { root
 frontendRoutes.get('/requests/:id', (req, res) => { res.sendFile('single.html', { root }); });
 frontendRoutes.get('/requests/edit/:id', (req, res) => { res.sendFile('modify.html', { root }); });
 frontendRoutes.get('/admin', (req, res) => { res.sendFile('admin/dashboard.html', { root }); });
+frontendRoutes.get('/admin/requests/:id', (req, res) => { res.sendFile('admin/single.html', { root }); });
 
 export default frontendRoutes;


### PR DESCRIPTION
#### What does this PR do?
For admin to be able to view a single request

#### Description of Task to be completed?
Imported the admin single request page ui and created the route
/admin/requests/<requestId>

#### How should this be manually tested?
After cloning the repo and running `npm install`
run `npm run dev` to start the server and 
point your browser to `http://localhost:8080/admin/requests/<requestId>`
after login

#### What are the relevant pivotal tracker stories?
#158174141